### PR TITLE
fix(account-service): fix register response

### DIFF
--- a/services/account-service/src/main/kotlin/org/katan/service/account/http/dto/AccountResponse.kt
+++ b/services/account-service/src/main/kotlin/org/katan/service/account/http/dto/AccountResponse.kt
@@ -18,7 +18,7 @@ public data class AccountResponse internal constructor(
     public constructor(account: Account) : this(
         id = account.id.toString(),
         username = account.username,
-        email = account.username,
+        email = account.email,
         createdAt = account.createdAt,
         updatedAt = account.createdAt,
         lastLoggedInAt = account.lastLoggedInAt


### PR DESCRIPTION
This PR makes the register route return the user's email on the `email` field instead of their username.

#24